### PR TITLE
only do RHEL-specific things on RHEL, allow Java package selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # UCLALib Ansible Role: Java
 
-Installs Java on RHEL linux servers from an official RedHat repository.
+Installs Java on a server in the RHEL family, optionally from an official RedHat repository.
 
 ## Default Variables
 
-  java_package - define the java package name to install
+  java_package - define the java package name to install (defaults to Oracle JDK 8)
   java_reponame - define the java repository to enable in subscription-manager
 
-This role first determines if it needs to enable the repository defined by `java_reponame`.
+This role first determines if it needs to enable the repository defined by `java_reponame`
+(only for RHEL, not for any other distribution)
 
 Then installs the package defined by `java_package`.
 
@@ -17,6 +18,9 @@ Example use in a playbook:
 - name: uclalib_java_app.yml
   sudo: true
   hosts: test
+
+  # Optionally specify the java_package to use, if not specified will default to Oracle JDK 8
+    - java_package: java-1.7.0-openjdk-devel.x86_64
 
   roles:
     - { role: uclalib_role_java }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,9 +6,13 @@
   failed_when: "repo_status.rc > 1"
   changed_when: "repo_status.rc == 1"
 
-- name: Enable RHEL third party oracle java repository.
+- name: Enable RHEL third party oracle java repository, skip when not on RedHat.
   command: /usr/sbin/subscription-manager repos --enable={{ java_reponame }}
-  when: repo_status.rc == 1
+  when: (repo_status.rc == 1) and
+        (ansible_distribution == "RedHat")
 
-- name: Install the Oracle JDK
+- name: Install the JDK specified by the PlayBook
   yum: name={{ java_package }} state=latest
+
+- name: Register JAVA_HOME env variable
+  lineinfile: dest=/etc/profile regexp="^(export JAVA_HOME=)" state=present line="export JAVA_HOME=/usr/lib/jvm/java"


### PR DESCRIPTION
Disables the RHEL-specific yum repository addition on distros that are not RHEL, and allows the playbook to specify (via a var) which Java package to use. Also adds a line to /etc/profile to define JAVA_HOME, as a convenience to Java users.
