### PR TITLE
Obtain Java directly from Oracle instead of via RHEL repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,33 @@
 # UCLALib Ansible Role: Java
 
-Installs Java on a server in the RHEL family, optionally from an official RedHat repository.
+Installs Oracle Java on server. RPM is obtained directly from Oracle.
 
-## Default Variables
+## Requirements
 
-  java_package - define the java package name to install (defaults to Oracle JDK 8)
-  java_reponame - define the java repository to enable in subscription-manager
+Only supports RHEL-family servers.
 
-This role first determines if it needs to enable the repository defined by `java_reponame`
-(only for RHEL, not for any other distribution)
+## Variables
 
-Then installs the package defined by `java_package`.
+`oracle_java_url` - defines the download URL for the Oracle Java rpm - No default is set - must specify in the play
 
-Example use in a playbook:
+`java_rpm_filename` - defines the filename of the Oracle Java rpm - file name is created based on the download URL
+
+`oracle_java_version` - defines the version of Oracle to be installed - No default is set - must specify in the play - Expected use: `"java version \"1.8.0_161\""`
+
+`java_rpm_md5` - defines the MD5 checksum of the Oracle Java rpm file - No default is set - must specify in play
+
+`java_home` - defines the filesystem path to the installed JRE - Default set to: `/usr/java/latest/jre`
+
+## Example Playbook:
 ```
 ---
 - name: uclalib_java_app.yml
   sudo: true
   hosts: test
-
-  # Optionally specify the java_package to use, if not specified will default to Oracle JDK 8
-    - java_package: java-1.7.0-openjdk-devel.x86_64
+  vars:
+    oracle_java_url: http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.rpm
+    oracle_java_version: "java version \"1.8.0_161\""
+    java_rpm_md5: f396f618b7c059089240563d2c46b5fc
 
   roles:
     - { role: uclalib_role_java }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,6 @@ java_rpm_filename: "{{ oracle_java_url.split('/')[8] }}"
 oracle_java_version: "java version \"1.8.0_161\""
 
 # Obtain from the checksum page for this version of Oracle Java
-java_rpm_sha256: d6808a4a7b96b72e8fbee28a223f94e43a07e970e757b87fc409644716ed7aa0
+java_rpm_md5: f396f618b7c059089240563d2c46b5fc
 
 java_home: /usr/java/latest/jre

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,11 +8,11 @@
 oracle_java_url: http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.rpm
 
 # This split statement grabs the rpm filename off the end of the oracle_java_url above
-java_rpm_filename: "{{ oracle_java_url.split('/')[2].split('/')[6] }}"
+java_rpm_filename: "{{ oracle_java_url.split('/')[8] }}"
 
 oracle_java_version: "\"1.8.0_161\""
 
-# Obtain from the checksum page for this version of Oracle Java 
+# Obtain from the checksum page for this version of Oracle Java
 java_rpm_sha256: d6808a4a7b96b72e8fbee28a223f94e43a07e970e757b87fc409644716ed7aa0
 
 java_home: /usr/java/latest/jre

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,14 +5,16 @@
 # and navigate to the Java version you want to download
 # You'll need to accept the license agreement
 # Then when you hover your mouse arrow over the download link, you'll see the download URL which you can copy/use
-oracle_java_url: http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.rpm
+# Example: http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.rpm
+oracle_java_url: ""
 
 # This split statement grabs the rpm filename off the end of the oracle_java_url above
 java_rpm_filename: "{{ oracle_java_url.split('/')[8] }}"
 
-oracle_java_version: "java version \"1.8.0_161\""
+# Example: "java version \"1.8.0_161\""
+oracle_java_version: ""
 
 # Obtain from the checksum page for this version of Oracle Java
-java_rpm_md5: f396f618b7c059089240563d2c46b5fc
+java_rpm_md5: ""
 
 java_home: /usr/java/latest/jre

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ oracle_java_url: http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b16
 # This split statement grabs the rpm filename off the end of the oracle_java_url above
 java_rpm_filename: "{{ oracle_java_url.split('/')[8] }}"
 
-oracle_java_version: "\"1.8.0_161\""
+oracle_java_version: "java version \"1.8.0_161\""
 
 # Obtain from the checksum page for this version of Oracle Java
 java_rpm_sha256: d6808a4a7b96b72e8fbee28a223f94e43a07e970e757b87fc409644716ed7aa0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,18 @@
 ---
-# Set java_version to the java package name you'd like to install
-# The package name should match what you find by doing a yum search package_name
-java_package: java-1.8.0-oracle-devel.x86_64
 
-# Set the RHEL subscription-manager repository name to use
-java_reponame: rhel-6-server-thirdparty-oracle-java-rpms
+# The default URL to the Oracle Java package you wish to download/install
+# Obtain this URL from http://www.oracle.com/technetwork/java/javase/downloads/index.html
+# and navigate to the Java version you want to download
+# You'll need to accept the license agreement
+# Then when you hover your mouse arrow over the download link, you'll see the download URL which you can copy/use
+oracle_java_url: http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jdk-8u161-linux-x64.rpm
+
+# This split statement grabs the rpm filename off the end of the oracle_java_url above
+java_rpm_filename: "{{ oracle_java_url.split('/')[2].split('/')[6] }}"
+
+oracle_java_version: "\"1.8.0_161\""
+
+# Obtain from the checksum page for this version of Oracle Java 
+java_rpm_sha256: d6808a4a7b96b72e8fbee28a223f94e43a07e970e757b87fc409644716ed7aa0
+
+java_home: /usr/java/latest/jre

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,23 @@
+- name: Download the Oracle Java RPM file
+  get_url:
+    url: "{{ oracle_java_url }}"
+    dest: "/opt/{{ java_rpm_filename }}"
+    headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
+    checksum: "sha256:{{ java_rpm_sha256 }}"
+
+- name: Install Oracle Java
+  yum:
+    name: "/opt/{{ java_rpm_filename }}"
+    state: present
+
+- name: Put in place JAVA_HOME env variable
+  lineinfile:
+    dest: /etc/profile
+    regexp: "^(export JAVA_HOME=)"
+    state: present
+    line: "export JAVA_HOME={{ java_home }}"
+
+- name: Clean-up Oracle Java RPM file
+  file:
+    path: "/opt/{{ java_rpm_filename }}"
+    state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Download the Oracle Java RPM file
   get_url:
     url: "{{ oracle_java_url }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,7 +5,7 @@
     url: "{{ oracle_java_url }}"
     dest: "/opt/{{ java_rpm_filename }}"
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
-    checksum: "sha256:{{ java_rpm_sha256 }}"
+    checksum: "md5:{{ java_rpm_md5 }}"
 
 - name: Install Oracle Java
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,4 +3,4 @@
 - include: verify.yml
 
 - include: install.yml
-  when: installed_oracle_java_version is defined and installed_oracle_java_version != oracle_java_version
+  when: installed_oracle_java_version is not defined or installed_oracle_java_version != oracle_java_version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,6 @@
 ---
 
-- name: Determine if oracle java repository needs to be enabled
-  shell: /usr/sbin/subscription-manager repos --list-enabled | grep Oracle
-  register: repo_status
-  failed_when: "repo_status.rc > 1"
-  changed_when: "repo_status.rc == 1"
+- include: verify.yml
 
-- name: Enable RHEL third party oracle java repository, skip when not on RedHat.
-  command: /usr/sbin/subscription-manager repos --enable={{ java_reponame }}
-  when: (repo_status.rc == 1) and
-        (ansible_distribution == "RedHat")
-
-- name: Install the JDK specified by the PlayBook
-  yum: name={{ java_package }} state=latest
-
-- name: Register JAVA_HOME env variable
-  lineinfile: dest=/etc/profile regexp="^(export JAVA_HOME=)" state=present line="export JAVA_HOME=/usr/lib/jvm/java"
+- inlcude: install.yml
+  when: installed_oracle_java_version != oracle_java_version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,5 @@
 
 - include: verify.yml
 
-- inlcude: install.yml
-  when: installed_oracle_java_version != oracle_java_version
+- include: install.yml
+  when: installed_oracle_java_version is defined and installed_oracle_java_version != oracle_java_version

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -6,7 +6,7 @@
 
 - block:
   - name: Determine version of Oracle Java installed
-    shell: {{ java_home }}/bin/java -version
+    shell: "{{ java_home }}/bin/java -version"
     register: java_version_output
 
   - name: Set installed Oracle Java version fact

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -4,12 +4,12 @@
   stat: path={{ java_home }}/bin/java
   register: java_install_status
 
-  - name: Determine version of Oracle Java installed
-    shell: "{{ java_home }}/bin/java -version"
-    register: java_version_output
-    when: java_install_status.stat.exists
+- name: Determine version of Oracle Java installed
+  shell: "{{ java_home }}/bin/java -version"
+  register: java_version_output
+  when: java_install_status.stat.exists
 
-  - name: Set installed Oracle Java version fact
-    set_fact:
-      installed_oracle_java_version: "{{ java_version_output.stderr | regex_search(\".*\") }}"
-    when: java_install_status.stat.exists
+- name: Set installed Oracle Java version fact
+  set_fact:
+    installed_oracle_java_version: "{{ java_version_output.stderr | regex_search(\".*\") }}"
+  when: java_install_status.stat.exists

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -4,12 +4,12 @@
   stat: path={{ java_home }}/bin/java
   register: java_install_status
 
-- block:
   - name: Determine version of Oracle Java installed
     shell: "{{ java_home }}/bin/java -version"
     register: java_version_output
+    when: java_install_status.stat.exists
 
   - name: Set installed Oracle Java version fact
     set_fact:
       installed_oracle_java_version: "{{ java_version_output.stderr | regex_search(\".*\") }}"
-when: java_install_status.stat.exists
+    when: java_install_status.stat.exists

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Determine if Oracle Java is installed
+  stat: path={{ java_home }}/bin/java
+  register: java_install_status
+
+- block:
+  - name: Determine version of Oracle Java installed
+    shell: {{ java_home }}/bin/java -version
+    register: java_version_output
+
+  - name: Set installed Oracle Java version fact
+    set_fact:
+      installed_oracle_java_version: "{{ java_version_output.stderr | regex_search(\".*\") }}"
+when: java_install_status.stat.exists


### PR DESCRIPTION
Red Hat will not longer support obtaining the Oracle version of Java through its repositories. Adjusting this ansible role to obtain java directly from Oracle. 