### PR TITLE
Add Oracle RPM signing key

### DIFF
--- a/tasks/oracle_install.yml
+++ b/tasks/oracle_install.yml
@@ -10,6 +10,11 @@
       Cookie: "oraclelicense=accept-securebackup-cookie"
     checksum: "md5:{{ java_rpm_md5 }}"
 
+- name: Install Oracle RPM GPG Keys
+  rpm_key:
+    key: https://yum.oracle.com/RPM-GPG-KEY-oracle-ol7
+    state: present
+
 - name: Install Oracle Java
   yum:
     name: "/opt/{{ java_rpm_filename }}"


### PR DESCRIPTION
Failed to validate GPG signature for jdk1.8-2000:1.8.0_191-fcs.x86_64

Uses the Oracle 7 key